### PR TITLE
BUG: Ensure numerizer works with any spaCy model

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ install:
   # Install pip modules
   - pip install flake8 nose coverage spacy
   - python -m spacy download en_core_web_sm
+  - python -m spacy download en_core_web_md
+  - python -m spacy download en_core_web_lg
   # Set up variables
   - export BRANCH=$TRAVIS_BRANCH
 

--- a/numerizer/numerizer.py
+++ b/numerizer/numerizer.py
@@ -2,7 +2,6 @@ import re
 from . import consts
 try:
     import spacy
-    nlp = spacy.load('en_core_web_sm')
     SPACY_INSTALLED = True
 except ImportError:
     SPACY_INSTALLED = False

--- a/test_numerize.py
+++ b/test_numerize.py
@@ -263,3 +263,20 @@ def test_span_token_extensions():
     doc = nlp('The projected revenue for the next quarter is over two million dollars.')
     assert doc[-4:-2]._.numerize() == '2000000'
     assert doc[6]._.numerized == '1/4'
+
+
+def test_spacy_models():
+    """Ensure that numerizer works with any spacy model."""
+    models = [
+        nlp,
+        load('en_core_web_md'),
+        load('en_core_web_lg'),
+    ]
+    for model in models:
+        doc = model('The Hogwarts Express is at platform nine and three quarters.')
+        numerized = doc._.numerize()
+        assert isinstance(numerized, dict)
+        assert len(numerized) == 1
+        key, val = numerized.popitem()
+        assert key.text == 'nine and three quarters'
+        assert val == '9.75'


### PR DESCRIPTION
Earlier it was restricted to en_core_web_sm. Now works with
en_core_web_md and en_core_web_lg. Closes #14