### PR TITLE
Big prefix bugfix

### DIFF
--- a/numerizer/numerizer.py
+++ b/numerizer/numerizer.py
@@ -209,7 +209,7 @@ def numerize_big_prefixes(s, ignore=None, bias=None):
                             except ValueError:
                                 # Fallback in case group_1 is unparseable like ". million"
                                 group_1_numberized = None
-                        if group_1_numberized:
+                        if group_1_numberized is not None:
                             repl = "<num>" + str(int(v * group_1_numberized))
                         else:
                             repl = str(v)

--- a/numerizer/numerizer.py
+++ b/numerizer/numerizer.py
@@ -204,8 +204,15 @@ def numerize_big_prefixes(s, ignore=None, bias=None):
                         try:
                             group_1_numberized = int(m.group(1))
                         except ValueError:
-                            group_1_numberized = float(m.group(1))
-                        repl = '<num>' + str(int(v * group_1_numberized))
+                            try:
+                                group_1_numberized = float(m.group(1))
+                            except ValueError:
+                                # Fallback in case group_1 is unparseable like ". million"
+                                group_1_numberized = None
+                        if group_1_numberized:
+                            repl = "<num>" + str(int(v * group_1_numberized))
+                        else:
+                            repl = str(v)
                     else:
                         repl = str(v)
                 except IndexError:

--- a/test_numerize.py
+++ b/test_numerize.py
@@ -80,7 +80,7 @@ def test_straight_parsing():
         99_999: "ninety nine thousand nine hundred ninety nine",
         100_000: "100 thousand",
         250_000: "two hundred fifty thousand",
-        1_000_000: ["one million", "1.0 million"],
+        1_000_000: ["one million", "1.0 million", ". Million"],
         1_200_000: "1.2 million",
         1_250_007: "one million two hundred fifty thousand and seven",
         1_000_000_000: "one billion",


### PR DESCRIPTION
When using the spacy integration, an improperly transcribed piece of text caused the parsing to fail. In this case it was "y. Million" (should have been "why millions").  This had a pattern match for `. Million`, but group_1 was `. `which can't be parsed to a number.

This PR just allows us to gracefully fall back to the best effort in that case.