### PR TITLE
Guard agaisnt ZeroDivisionError

### DIFF
--- a/numerizer/numerizer.py
+++ b/numerizer/numerizer.py
@@ -262,7 +262,7 @@ def cleanup_fractions(s):
     pat = re.compile(r'(\d+)(?: | and |-)+(<num>|\s)*(\d+)\s*\/\s*(\d+)',
                      flags=re.IGNORECASE)
     m = re.search(pat, s)
-    if m is not None:
+    if m is not None and float(m.group(4)) != 0.0:
         def _repl_frac_cleanup(m):
             return str(float(m.group(1)) + (float(m.group(3)) / float(m.group(4))))
         s = re.sub(pat, _repl_frac_cleanup, s)

--- a/test_numerize.py
+++ b/test_numerize.py
@@ -196,6 +196,7 @@ def test_ambiguous_cases():
     # assert 'the 2nd second' == numerize('the second second')
     # assert 'the 4th second' == numerize('the fourth second')
     # assert '1 second' == numerize('one second')
+    assert "0-4/0" == numerize("0-4/0")
 
 
 # TODO: Find way to distinguish this verb


### PR DESCRIPTION
This should only happen with weirdly formatted text, but this stops it from crashing.